### PR TITLE
moving xtend to 'dependencies' from 'devDependencies' in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "posix"
   ],
   "dependencies": {
-    "concat-stream": "^1.4.7"
+    "concat-stream": "^1.4.7",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.2",
-    "tape": "^3.0.3",
-    "xtend": "^4.0.0"
+    "tape": "^3.0.3"
   },
   "scripts": {
     "test": "node test",


### PR DESCRIPTION
# Issue

The following command cause error due to absent `xtend`

```
npm install shell-source
```
# Fix
- moving `xtend` to `dependencies` from `devDependencies` in `package.json`
