### PR TITLE
Update index.js to support windows (untested!)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var spawn = require('child_process').spawn;
 var concat = require('concat-stream');
 var xtend = require('xtend');
+var path = require('path');
 
 var reserved = {
   'SHLVL': true,
@@ -18,7 +19,11 @@ module.exports = function(filename, opts, cb) {
   }
 
   if (!opts.wrapper) {
-    opts.wrapper = __dirname + '/source.sh';
+    opts.wrapper = path.join(__dirname, 'source.sh');
+  }
+
+  if (!opts.shell) {
+    opts.shell = 'bash';
   }
 
   if (!opts.reserved) {
@@ -33,7 +38,7 @@ module.exports = function(filename, opts, cb) {
   var status = null;
   var stdout = null;
   var stderr = null;
-  var proc = spawn(opts.wrapper, [ filename ]);
+  var proc = spawn(opts.shell, [opts.wrapper, filename]);
   
   proc.on('error', function(err) {
     cb(err);

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var spawn = require('child_process').spawn;
 var concat = require('concat-stream');
 var xtend = require('xtend');
-var path = require('path');
 
 var reserved = {
   'SHLVL': true,
@@ -19,11 +18,11 @@ module.exports = function(filename, opts, cb) {
   }
 
   if (!opts.wrapper) {
-    opts.wrapper = path.join(__dirname, 'source.sh');
+    opts.wrapper = __dirname + '/source.sh';
   }
 
   if (!opts.shell) {
-    opts.shell = 'bash';
+    opts.shell = 'sh';
   }
 
   if (!opts.reserved) {


### PR DESCRIPTION
i discovered this on a new windows tablet by accident. I tested with Git Bash for Windows. This might break Linux or other Windows shells so be cautious and give it some extra testing.

Changes:
- instead of spawning the shellwrapper (.sh file) directly i do now spawn the "bash" aka opts.shell (so you can specify own shell).
- using path.join for concatenating file paths